### PR TITLE
Retry when getting tags

### DIFF
--- a/mirror.go
+++ b/mirror.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	httpClient = &http.Client{Timeout: 10 * time.Second}
+	httpClient = &http.Client{Timeout: 20 * time.Second}
 )
 
 // TagsResponse is Docker Registry v2 compatible struct
@@ -279,7 +279,22 @@ func (m *mirror) getRemoteTags() ([]RepositoryTag, error) {
 
 	var allTags []RepositoryTag
 	for {
-		r, err := httpClient.Get(url)
+        var (
+            err      error
+            r *http.Response
+            retries  int = 5
+        )
+
+        for retries > 0 {
+                r, err = httpClient.Get(url)
+            if err != nil {
+                log.Warningf("Failed to get %s, retrying", url)
+                retries -= 1
+            } else {
+                break
+            }
+        }
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`docker-mirror` will obtain the complete list of tags using the paginated API, before pulling the image. Some repos can have a huge amount of tags though, which makes the endpoint very slow and prone to failure. This PR adds retries to the API call to be resistant against this endpoint failing. This is however only a workaround, as for some repos, e.g., [armory/clouddriver](https://registry.hub.docker.com/r/armory/clouddriver), 171 calls are made to this image which takes more than an hour.